### PR TITLE
x#xdeploy: add the possibility of building in a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build*
+/cmake-build*
+/release
+/.conan/
+/.idea/
 /.vs/*
 /.vscode
-/cmake-build*
-/.idea/
-/release

--- a/README.md
+++ b/README.md
@@ -61,33 +61,65 @@ volumes:
   influxdb:
 ```
 
-## Compiling the Image locally
+You're good to go: `http://localhost:8080`
 
-You'll need:
+## Compiling
 
-- **Docker** >= v15
-- **Docker-compose** >= v1.20
+You can either build locally on your host with an appropriate environment
+or in a Docker container that produces a reference environment.
+
+### Dependencies:
+
 - **CMake** >= v3.9
 - **Conan** >= v1
 - **C++17** compiler
+- **NodeJS** >= v8
 
-Steps:
+### The sources
+
+The project is made of a master repo plus third-party components.
 
 ```
 git clone https://github.com/ebu/pi-list.git
 git submodule update --init --recursive
+```
+
+### Linux (Debian) host build
+
+Additional requirements:
+
+- **uuid-dev**
+- **libpcap-dev**
+
+Fetch the project, build the dependencies and the project:
+
+```
 ./scripts/setup-dev-env.sh
 ./scripts/deploy/deploy.sh
 ```
 
-A new folder `release` will appear on the top-level directory of this repository.
+### Docker build
+
+**Docker** >= v15 is needed.
+
+From the top directory, use the docker wrapper script:
+
+```
+./scripts/docker_build_wrapper.sh
+Usage:  ./scripts/docker_build_wrapper.sh <init|build|bash>
+    init   Generate a Dockerfile and the Docker image list_dev_env
+    build  Build LIST project using a container based on list_dev_env
+    bash   Start bash in the conatiner for dev or troubleshoot.
+```
+
+### Output
+
+A new folder `release` will appear on the top-level directory of this repository. It contains the artefact to be installed on the LIST server and all docker-compose files to instanciate all the micros-services.
 
 ```
 cd release
 ./start.sh
 ```
-
-You're good to go: `http://localhost:8080`
 
 ## Development
 ### Pre-requisites

--- a/scripts/deploy/artifacts/docker-compose.yml
+++ b/scripts/deploy/artifacts/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - mongo:/data/db
 
   list_server:
-    build: .
+    build: ./server/
     ports:
       - "8080:8080"
       - "3030:3030"

--- a/scripts/deploy/artifacts/listwebserver/Dockerfile
+++ b/scripts/deploy/artifacts/listwebserver/Dockerfile
@@ -1,17 +1,19 @@
+# This is the LIST server's runtime Dockerfile
+
 FROM gcc:7.2
 
 # Install node
 RUN curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
 RUN bash nodesource_setup.sh
 RUN apt-get install -y nodejs
-RUN apt-get install -y ffmpeg
-
 RUN npm install -g serve
+
+RUN apt-get install -y ffmpeg
 
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/usr/local/lib/
 
-ADD server/app/ /app
-ADD server/lib/ /usr/local/lib
+ADD app/ /app
+ADD lib/ /usr/local/lib
 
 WORKDIR /app/listwebserver/
 RUN npm install

--- a/scripts/deploy/build.sh
+++ b/scripts/deploy/build.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 SCRIPT_DIR="$(dirname $(readlink -f $0))"
-TOP_DIR="$SCRIPT_DIR/../.."
+TOP_DIR="$(readlink -f $SCRIPT_DIR/../..)"
 BUILD_DIR="$TOP_DIR/build"
+
+LD_LIBRARY_PATH=/usr/local/lib/
 
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -38,13 +38,12 @@ rsync -ahv $TOP_DIR/apps/gui/dist/* $RELEASE_DIR/server/app/gui
 echo "Copying apps... done"
 
 echo
-echo "Copying scripts..."
+echo "Copying artifacts..."
 install -m 755 $SCRIPT_DIR/artifacts/*.sh $RELEASE_DIR/
-install -m 644 $SCRIPT_DIR/artifacts/*ocker* $RELEASE_DIR/
-echo "Copying scripts... done"
-
-echo "Copying config..."
+install -m 755 $SCRIPT_DIR/artifacts/docker-compose.yml $RELEASE_DIR/
+install -m 644 $SCRIPT_DIR/artifacts/listwebserver/Dockerfile $RELEASE_DIR/server/
 install -m 644 $SCRIPT_DIR/artifacts/listwebserver/config.yml $RELEASE_DIR/server/app/listwebserver
+echo "Copying artifacts... done"
 
 echo
 echo "Deploy is ready in $RELEASE_DIR.

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(dirname $(readlink -f $0))"
 TOP_DIR="$(readlink -f $SCRIPT_DIR/../..)"
 RELEASE_DIR="$TOP_DIR/release"
 
+# conan custom config
+conan config install https://github.com/bisect-pt/conan_config.git
+
 # Builds CPP code
 source $SCRIPT_DIR/build.sh
 

--- a/scripts/docker_build_wrapper.sh
+++ b/scripts/docker_build_wrapper.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# This script creates a build environment in a docker container to be
+# used to compile the whole project.
+# The project directory is mounted as a volume in the container to allow
+# both container and native system user to access everything r/w. The
+# container user ID is mapped to the native system user ID in order to
+# preserve the ownership of the build artefacts.
+
+SCRIPT_DIR="$(dirname $(readlink -f $0))"
+TOP_DIR="$(readlink -f $SCRIPT_DIR/..)"
+USER=builder
+IMAGE=list_dev_env
+DOCKERFILE=$TOP_DIR/release/Dockerfile
+
+usage(){
+    echo "Usage: $basename $0 <init|build|bash>
+    init   Generate a Dockerfile and the Docker image $IMAGE
+    build  Build LIST project using a container based on $IMAGE
+    bash   Start bash in the container for dev or troubleshoot."
+}
+
+init() {
+    if [ ! -f $DOCKERFILE ]
+    then
+        mkdir -p $TOP_DIR/release/
+        echo "Creating $DOCKERFILE"
+        cat > $DOCKERFILE << EOF
+# This is the "builder" Dockerfile
+
+FROM gcc:7.2
+
+RUN apt update
+
+RUN adduser --uid $UID --home /home/$USER $USER
+
+ADD ./scripts/ /home/$USER/scripts/
+WORKDIR /home/$USER/
+RUN ./scripts/setup-dev-env.sh
+EOF
+    else
+        echo ""
+        echo "$DOCKERFILE already exits"
+    fi
+
+    echo "Creating the Docker image"
+    docker build --rm -t $IMAGE -f $DOCKERFILE $TOP_DIR
+}
+
+build() {
+    docker run -u $USER -v $TOP_DIR:/home/$USER -it $IMAGE:latest ./scripts/deploy/deploy.sh
+}
+
+run_bash() {
+    docker run -u $USER -v $TOP_DIR:/home/$USER -it $IMAGE:latest bash
+}
+
+case $1 in
+    init)
+        init
+        ;;
+    build)
+        build
+        ;;
+    bash)
+        run_bash
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
+# get cmake 3.9
+echo "deb http://ftp.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/stretch-backports.list
+apt update
+apt -t stretch-backports install -y --no-install-recommends cmake
+
+# utilities
+apt install -y curl rsync python-pip
+pip install conan
+
+# node
+curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
+bash nodesource_setup.sh
+apt install -y nodejs npm
+rm -f nodesource_setup.sh
+
 apt install -y uuid-dev libpcap-dev
-
-conan config install https://github.com/bisect-pt/conan_config.git
-
-if which node > /dev/null
-then
-    echo "node is installed, skipping..."
-else
-    apt install -y curl
-    curl -sL https://deb.nodesource.com/setup_8.x -o nodesource_setup.sh
-    bash nodesource_setup.sh
-    apt install -y nodejs npm
-fi
 
 echo "Please install FFMPEG v2.8 or newer using your package manager or https://www.ffmpeg.org/download.html"
 echo "If you're going to run LIST via Docker, ignore the above message, as FFMPEG it's already installed on Docker image"


### PR DESCRIPTION
This provides a consistent and controlled build environment while keeping
a native sane environment.

* a docker wrapper script is added
* the docker image init relies on the improved setup script
* the doc is refactored to help understanding the multiple build cases
* the build had a minor variable expansion issue which caused an exit