### PR TITLE
changing CORS default domain to any fix #12

### DIFF
--- a/apps/listwebserver/config.yml
+++ b/apps/listwebserver/config.yml
@@ -8,7 +8,7 @@ cpp: /home/mpoeira/list/live/cmake-build-debug/third_party/ebu_list/bin/
 
 # HTTP-related
 cookieSecret: STRD4O
-webappDomain: http://localhost:8080
+webappDomain: *
 
 # MongoDB database
 database:


### PR DESCRIPTION
Fix #12 

This means the CORS pref-light checks will always pass unless configured otherwise. [link\(https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) it is used [here](https://github.com/ebu/pi-list/blob/390cd8a62d466b7a4e5157d218161b0f794f125a/apps/listwebserver/app.js#L22) and prevents access from anything other than localhost

> Access-Control-Allow-Origin specifies either a single origin, which tells browsers to allow that origin to access the resource; or else — for requests without credentials — the " * " wildcard, to tell browsers to allow any origin to access the resource.